### PR TITLE
Fix CV page rendering duplicate text below PDF pages

### DIFF
--- a/src/components/PdfViewer.js
+++ b/src/components/PdfViewer.js
@@ -28,8 +28,8 @@ const PdfViewer = () => {
   return (
     <Box style={{ display: "flex", flexDirection: "row", gap: "0px" }}>
       <PDFDocument file={url} className="d-flex justify-content-center">
-        <PDFPage pageNumber={1} scale={width > 786 ? 1.5 : 0.6} renderAnnotationLayer={false}/>
-        <PDFPage pageNumber={2} scale={width > 786 ? 1.5 : 0.6} renderAnnotationLayer={false}/>
+        <PDFPage pageNumber={1} scale={width > 786 ? 1.5 : 0.6} renderAnnotationLayer={false} renderTextLayer={false}/>
+        <PDFPage pageNumber={2} scale={width > 786 ? 1.5 : 0.6} renderAnnotationLayer={false} renderTextLayer={false}/>
       </PDFDocument>
     </Box>
   );


### PR DESCRIPTION
## Summary
- Disable react-pdf text layer in `PdfViewer.js` — the required `TextLayer.css` is not imported, so pdf.js was rendering extracted text as raw, unstyled content below each page.
- CV is display-only; no need for a selectable text layer.

## Test plan
- [ ] Visit `/cv` and confirm both PDF pages render without duplicated raw text below them.
- [ ] Verify both desktop (>786px) and mobile scales still render.